### PR TITLE
Fixing an issue with relative path in yam filename

### DIFF
--- a/plugin/add_yaml_key
+++ b/plugin/add_yaml_key
@@ -60,6 +60,7 @@ key = ARGV[1]
 value = ARGV[2]
 
 locale = File.basename(file, ".yml")[/[^\.]+$/]
+file = File.expand_path(file)
 file_content = File.exists?(file) ? File.read(file) : "#{locale}:"
 yamlator = YAMLator.new(file_content)
 yamlator[yamlator.hash.keys.first + "." + key] = value


### PR DESCRIPTION
When using relative paths for YAML files (like ~/Sites/my_site/config/locales/en.yml'), they are not affected, at least on Mac OS X machines. That's because of Ruby not seeing a file within such locations.

Just to note. Personally I use relative paths because my vim configured to change the working directory to the currently opened file. So something like 'config/locales/en.yml' just doesn't work.
